### PR TITLE
Ensure camera cleanup runs on main thread

### DIFF
--- a/app/src/main/java/com/example/travelguide/camera/CameraModule.kt
+++ b/app/src/main/java/com/example/travelguide/camera/CameraModule.kt
@@ -120,8 +120,10 @@ class CameraModule(
     /** Stops the camera and releases resources. */
     fun stopCamera() {
         try {
-            imageAnalysis?.clearAnalyzer()
-            cameraProvider?.unbindAll()
+            activity.runOnUiThread {
+                imageAnalysis?.clearAnalyzer()
+                cameraProvider?.unbindAll()
+            }
         } catch (e: CameraAccessException) {
             if (e.reason == CameraAccessException.CAMERA_DISCONNECTED) {
                 handleCameraDisconnected(e)
@@ -145,8 +147,10 @@ class CameraModule(
             TAG,
             "Camera disconnected (CameraAccessException.CAMERA_DISCONNECTED): ${e.message}"
         )
-        releaseResources()
-        scheduleReconnect()
+        activity.runOnUiThread {
+            releaseResources()
+            scheduleReconnect()
+        }
     }
 
     private fun scheduleReconnect() {
@@ -162,8 +166,10 @@ class CameraModule(
 
     private fun releaseResources() {
         try {
-            imageAnalysis?.clearAnalyzer()
-            cameraProvider?.unbindAll()
+            activity.runOnUiThread {
+                imageAnalysis?.clearAnalyzer()
+                cameraProvider?.unbindAll()
+            }
         } catch (e: Exception) {
             Log.w(TAG, "Error releasing camera resources: ${e.message}")
         } finally {


### PR DESCRIPTION
## Summary
- Run clearAnalyzer and unbindAll on the UI thread in `stopCamera` and `releaseResources`
- Execute camera disconnection handling on the main thread

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896185361488324950fd3a7490a5a7c