### PR TITLE
Use FloatBuffer for AR background UVs

### DIFF
--- a/app/src/main/java/com/example/travelguide/ar/BackgroundRenderer.kt
+++ b/app/src/main/java/com/example/travelguide/ar/BackgroundRenderer.kt
@@ -97,11 +97,19 @@ class BackgroundRenderer {
 
     fun draw(frame: Frame) {
         if (textureId == -1 || program == 0) return
-        val transformed = FloatArray(quadTexCoords.size)
-        frame.transformDisplayUvCoords(quadTexCoords, transformed)
+        val transformedBuffer = ByteBuffer.allocateDirect(quadTexCoords.size * 4)
+            .order(ByteOrder.nativeOrder())
+            .asFloatBuffer()
         quadTexCoordBuffer.apply {
             clear()
-            put(transformed)
+            put(quadTexCoords)
+            position(0)
+        }
+        frame.transformDisplayUvCoords(quadTexCoordBuffer, transformedBuffer)
+        transformedBuffer.position(0)
+        quadTexCoordBuffer.apply {
+            clear()
+            put(transformedBuffer)
             position(0)
         }
         GLES20.glDepthMask(false)


### PR DESCRIPTION
## Summary
- Use direct FloatBuffer for camera background UV transformation
- Pass FloatBuffers to `transformDisplayUvCoords`
- Reload transformed coordinates into OpenGL buffer

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b794f5b088324b0638a9d0583fa04