### PR TITLE
refactor: update background renderer for new ARCore API

### DIFF
--- a/app/src/main/java/com/example/travelguide/ar/BackgroundRenderer.kt
+++ b/app/src/main/java/com/example/travelguide/ar/BackgroundRenderer.kt
@@ -2,6 +2,7 @@ package com.example.travelguide.ar
 
 import android.opengl.GLES11Ext
 import android.opengl.GLES20
+import com.google.ar.core.Coordinates2d
 import com.google.ar.core.Frame
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -105,7 +106,12 @@ class BackgroundRenderer {
             put(quadTexCoords)
             position(0)
         }
-        frame.transformDisplayUvCoords(quadTexCoordBuffer, transformedBuffer)
+        frame.transformCoordinates2d(
+            Coordinates2d.TEXTURE_NORMALIZED,
+            quadTexCoordBuffer,
+            Coordinates2d.DISPLAY_NORMALIZED,
+            transformedBuffer
+        )
         transformedBuffer.position(0)
         quadTexCoordBuffer.apply {
             clear()


### PR DESCRIPTION
## Summary
- replace deprecated `transformDisplayUvCoords` with `transformCoordinates2d`
- use `Coordinates2d.TEXTURE_NORMALIZED` -> `Coordinates2d.DISPLAY_NORMALIZED` for quad texture mapping

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8224cd1c83248a359e64d6dea007