### PR TITLE
Remove experimental Camera2Interop opt-in

### DIFF
--- a/app/src/main/java/com/example/travelguide/camera/CameraModule.kt
+++ b/app/src/main/java/com/example/travelguide/camera/CameraModule.kt
@@ -16,7 +16,6 @@ import androidx.camera.core.Preview
 import androidx.camera.core.UseCase
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.camera2.interop.Camera2Interop
-import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.view.PreviewView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -65,7 +64,6 @@ class CameraModule(
     }
 
     /** Binds [Preview] and optional [ImageAnalysis] use cases. */
-    @OptIn(ExperimentalCamera2Interop::class)
     private fun bindCameraUseCases() {
         val provider = cameraProvider ?: return
         val executor = cameraExecutor


### PR DESCRIPTION
## Summary
- drop ExperimentalCamera2Interop opt-in annotation from camera module

## Testing
- `gradle assembleDebug --warning-mode all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b89c982808324a8eaec740ea212cc