### PR TITLE
Remove unnecessary not-null assertion for camera frame analyzer

### DIFF
--- a/app/src/main/java/com/example/travelguide/camera/CameraModule.kt
+++ b/app/src/main/java/com/example/travelguide/camera/CameraModule.kt
@@ -89,7 +89,7 @@ class CameraModule(
             })
 
             builder.build().also {
-                it.setAnalyzer(executor, ThrottledAnalyzer(frameCallback!!))
+                it.setAnalyzer(executor, ThrottledAnalyzer(frameCallback))
             }
         } else {
             null


### PR DESCRIPTION
## Summary
- Pass frameCallback directly to ThrottledAnalyzer instead of using `!!`
- ThrottledAnalyzer continues to require a non-null ImageProxy callback

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c95390c8324a2a20cb3baa16c01