### PR TITLE
Check and install ARCore before initializing session

### DIFF
--- a/app/src/main/java/com/example/travelguide/ar/ARModule.kt
+++ b/app/src/main/java/com/example/travelguide/ar/ARModule.kt
@@ -1,5 +1,6 @@
 package com.example.travelguide.ar
 
+import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -17,6 +18,8 @@ import com.google.ar.core.*
 import com.google.ar.core.exceptions.CameraNotAvailableException
 import com.google.ar.core.exceptions.NotYetAvailableException
 import com.google.ar.core.exceptions.UnavailableException
+import android.util.Log
+import android.widget.Toast
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.acos
@@ -55,12 +58,29 @@ class ARModule(
      */
     fun initializeIfPermitted(context: Context) {
         if (session != null) return
+        val availability = ArCoreApk.getInstance().checkAvailability(context)
+        if (availability != ArCoreApk.Availability.INSTALLED) {
+            if (context is Activity) {
+                try {
+                    ArCoreApk.getInstance().requestInstall(context, true)
+                } catch (e: UnavailableException) {
+                    Log.e("ARModule", "ARCore install request failed", e)
+                }
+            }
+            Toast.makeText(
+                context,
+                "Instala o actualiza ARCore para continuar",
+                Toast.LENGTH_LONG
+            ).show()
+            return
+        }
         session = try {
             Session(context).apply {
                 val config = Config(this)
                 configure(config)
             }
         } catch (e: UnavailableException) {
+            Log.e("ARModule", "Failed to create ARCore session", e)
             null
         }
     }


### PR DESCRIPTION
## Summary
- Validate ARCore availability before starting session
- Request ARCore install/update when missing and notify user
- Log ARCore session initialization failures for easier diagnostics

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f52f2a98c8324a463f21a28c45593